### PR TITLE
Implement slash command interaction

### DIFF
--- a/src/interactions/mod.rs
+++ b/src/interactions/mod.rs
@@ -8,6 +8,9 @@ use serenity::{
 mod msg_command;
 pub(crate) use msg_command::MsgCommand;
 
+mod slash_command;
+pub(crate) use slash_command::SlashCommand;
+
 #[async_trait]
 pub trait RRCommandInteraction {
     fn name(&self) -> String;

--- a/src/interactions/mod.rs
+++ b/src/interactions/mod.rs
@@ -1,0 +1,39 @@
+use serenity::{
+    all::{
+        CommandInteraction, Context, CreateInteractionResponse, CreateInteractionResponseMessage, Ready,
+    },
+    async_trait,
+};
+
+mod msg_command;
+pub(crate) use msg_command::MsgCommand;
+
+#[async_trait]
+pub trait RRCommandInteraction {
+    fn name(&self) -> String;
+
+    fn can_handle(&self, interaction: &CommandInteraction) -> bool;
+
+    async fn handle_impl(
+        &self,
+        interaction: &CommandInteraction,
+    ) -> Result<CreateInteractionResponse, String>;
+    async fn handle(
+        &self,
+        ctx: &Context,
+        interaction: &CommandInteraction,
+    ) -> Result<(), serenity::Error> {
+        let response = match self.handle_impl(interaction).await {
+            Ok(r) => r,
+            Err(e) => CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .content(format!("Error: {e}"))
+                    .ephemeral(true),
+            ),
+        };
+        interaction.create_response(&ctx.http, response).await?;
+        Ok(())
+    }
+
+    async fn register(&self, ctx: &Context, ready: &Ready) -> Result<(), serenity::Error>;
+}

--- a/src/interactions/msg_command.rs
+++ b/src/interactions/msg_command.rs
@@ -1,0 +1,60 @@
+use serenity::{
+    all::{
+        Command, CommandInteraction, CommandType, Context, CreateCommand,
+        CreateInteractionResponse, CreateInteractionResponseMessage, Ready,
+    },
+    async_trait,
+    futures::future,
+};
+
+use crate::links::find_platform_links;
+
+use super::RRCommandInteraction;
+
+const MSG_COMMAND_NAME: &str = "Alt URLs";
+pub struct MsgCommand;
+
+#[async_trait]
+impl RRCommandInteraction for MsgCommand {
+    fn name(&self) -> String {
+        "message command".to_owned()
+    }
+
+    fn can_handle(&self, interaction: &CommandInteraction) -> bool {
+        interaction.data.name.as_str() == MSG_COMMAND_NAME
+            && interaction.data.kind == CommandType::Message
+    }
+
+    async fn handle_impl(
+        &self,
+        interaction: &CommandInteraction,
+    ) -> Result<CreateInteractionResponse, String> {
+        debug_assert!(self.can_handle(interaction));
+
+        let messages = interaction.data.resolved.messages.values();
+        let alt_urls = future::join_all(
+            messages
+                .flat_map(|msg| find_platform_links(&msg.content))
+                .map(|link| link.alternative_links()),
+        )
+        .await
+        .into_iter()
+        .flatten()
+        .map(|link| link.to_string())
+        .collect::<Vec<_>>();
+
+        if alt_urls.is_empty() {
+            Err("Provided links are not supported :(".to_owned())
+        } else {
+            let reply_msg = CreateInteractionResponseMessage::new().content(alt_urls.join("\n"));
+            Ok(CreateInteractionResponse::Message(reply_msg))
+        }
+    }
+
+    async fn register(&self, ctx: &Context, _ready: &Ready) -> Result<(), serenity::Error> {
+        let msg_command = CreateCommand::new(MSG_COMMAND_NAME).kind(CommandType::Message);
+        Command::create_global_command(&ctx.http, msg_command).await?;
+
+        Ok(())
+    }
+}

--- a/src/interactions/slash_command.rs
+++ b/src/interactions/slash_command.rs
@@ -1,0 +1,84 @@
+use serenity::{
+    all::{
+        Command, CommandInteraction, CommandOptionType, CommandType, Context, CreateCommand,
+        CreateCommandOption, CreateInteractionResponse, CreateInteractionResponseMessage, Ready,
+    },
+    async_trait,
+};
+use url::Url;
+
+use crate::links::PlatformLink;
+
+use super::RRCommandInteraction;
+
+const SLASH_COMMAND_NAME: &str = "alturls";
+pub struct SlashCommand;
+
+#[async_trait]
+impl RRCommandInteraction for SlashCommand {
+    fn name(&self) -> String {
+        "slash command".to_owned()
+    }
+
+    fn can_handle(&self, interaction: &CommandInteraction) -> bool {
+        if interaction.data.name.as_str() != SLASH_COMMAND_NAME
+            || interaction.data.kind != CommandType::ChatInput
+        {
+            return false;
+        }
+
+        // sanity checks
+        if interaction.data.options.len() != 1 {
+            println!("slash command should have 1 option");
+            return false;
+        }
+        if interaction.data.options[0].kind() != CommandOptionType::String {
+            println!("slash command should have 1 option");
+            return false;
+        }
+
+        true
+    }
+
+    async fn handle_impl(
+        &self,
+        interaction: &CommandInteraction,
+    ) -> Result<CreateInteractionResponse, String> {
+        debug_assert!(self.can_handle(interaction));
+
+        let url = interaction.data.options[0].value.as_str().unwrap();
+        let url = Url::parse(url).map_err(|e| format!("failed to parse url: {e}"))?;
+        let link = PlatformLink::try_from(url)
+            .map_err(|e| format!("failed to parse plaform link: {e}"))?;
+        let alt_urls = link.alternative_links().await;
+
+        if alt_urls.is_empty() {
+            Err("Provided link is not supported :(".to_owned())
+        } else {
+            let content = alt_urls
+                .into_iter()
+                .map(|link| link.to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let reply_msg = CreateInteractionResponseMessage::new().content(content);
+            Ok(CreateInteractionResponse::Message(reply_msg))
+        }
+    }
+
+    async fn register(&self, ctx: &Context, _ready: &Ready) -> Result<(), serenity::Error> {
+        let slash_command = CreateCommand::new(SLASH_COMMAND_NAME)
+            .kind(CommandType::ChatInput)
+            .description("Get alternative URLs for the provided link")
+            .add_option(
+                CreateCommandOption::new(
+                    CommandOptionType::String,
+                    "url",
+                    "The URL to get alternative links for",
+                )
+                .required(true),
+            );
+        Command::create_global_command(&ctx.http, slash_command).await?;
+
+        Ok(())
+    }
+}

--- a/src/links/mod.rs
+++ b/src/links/mod.rs
@@ -3,7 +3,8 @@ use std::{borrow::Cow, fmt::Display};
 use linkify::{LinkFinder, LinkKind};
 use url::Url;
 
-use crate::reddit::{alternative_reddit_links, resolve_reddit_share_link};
+mod reddit;
+use reddit::{alternative_reddit_links, resolve_reddit_share_link};
 
 pub enum Link {
     Simple(String),

--- a/src/links/reddit.rs
+++ b/src/links/reddit.rs
@@ -3,7 +3,7 @@
 use reqwest::{header::LOCATION, redirect, Client};
 use url::Url;
 
-use crate::links::{get_platform_link, Link, PlatformLink};
+use super::{get_platform_link, Link, PlatformLink};
 
 pub async fn resolve_reddit_share_link(subreddit: &str, share_id: &str) -> Option<PlatformLink> {
     let client = Client::builder()

--- a/src/links/reddit.rs
+++ b/src/links/reddit.rs
@@ -3,7 +3,7 @@
 use reqwest::{header::LOCATION, redirect, Client};
 use url::Url;
 
-use super::{get_platform_link, Link, PlatformLink};
+use super::{Link, PlatformLink};
 
 pub async fn resolve_reddit_share_link(subreddit: &str, share_id: &str) -> Option<PlatformLink> {
     let client = Client::builder()
@@ -22,7 +22,9 @@ pub async fn resolve_reddit_share_link(subreddit: &str, share_id: &str) -> Optio
     dbg!(&real_link);
 
     // filter to avoid infinite recursion
-    get_platform_link(real_link).filter(|pl| matches!(pl, PlatformLink::RedditPost { .. }))
+    PlatformLink::try_from(real_link)
+        .ok()
+        .filter(|pl| matches!(pl, PlatformLink::RedditPost { .. }))
 }
 
 pub fn alternative_reddit_links(

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
 mod links;
-mod reddit;
 
 const COMMAND_NAME: &str = "Alt URLs";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use serenity::prelude::*;
 mod links;
 
 mod interactions;
-use interactions::{MsgCommand, RRCommandInteraction};
+use interactions::{MsgCommand, RRCommandInteraction, SlashCommand};
 
 #[tokio::main]
 async fn main() {
@@ -32,7 +32,7 @@ struct Handler {
 impl Handler {
     fn new() -> Self {
         Self {
-            command_interactions: vec![Box::new(MsgCommand)],
+            command_interactions: vec![Box::new(MsgCommand), Box::new(SlashCommand)],
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,68 +1,14 @@
 use std::env;
 
-use links::find_platform_links;
-use serenity::all::{CommandInteraction, CommandType, CreateCommand};
 use serenity::async_trait;
-use serenity::builder::{CreateInteractionResponse, CreateInteractionResponseMessage};
-use serenity::futures::future;
-use serenity::model::application::{Command, Interaction};
+use serenity::model::application::Interaction;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
 mod links;
 
-const COMMAND_NAME: &str = "Alt URLs";
-
-async fn handle_alt_urls_command(ctx: Context, interaction: CommandInteraction) {
-    let messages = interaction.data.resolved.messages.values();
-    let links = future::join_all(
-        messages
-            .flat_map(|msg| find_platform_links(&msg.content))
-            .map(|link| link.alternative_links()),
-    )
-    .await
-    .iter()
-    .flatten()
-    .map(|link| link.to_string())
-    .collect::<Vec<_>>();
-
-    let data = if links.is_empty() {
-        CreateInteractionResponseMessage::new()
-            .content("No supported links found in message :(")
-            .ephemeral(true)
-    } else {
-        CreateInteractionResponseMessage::new().content(links.join("\n"))
-    };
-    let builder = CreateInteractionResponse::Message(data);
-    if let Err(why) = interaction.create_response(&ctx.http, builder).await {
-        println!("Cannot respond to slash command: {why}");
-    }
-}
-
-struct Handler;
-
-#[async_trait]
-impl EventHandler for Handler {
-    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        if let Interaction::Command(command) = interaction {
-            if let (COMMAND_NAME, CommandType::Message) =
-                (command.data.name.as_str(), command.data.kind)
-            {
-                handle_alt_urls_command(ctx, command).await
-            }
-        }
-    }
-
-    async fn ready(&self, ctx: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
-
-        // register message command
-        let alt_url_command = CreateCommand::new(COMMAND_NAME).kind(CommandType::Message);
-        Command::create_global_command(&ctx.http, alt_url_command)
-            .await
-            .expect("Failed to register message command");
-    }
-}
+mod interactions;
+use interactions::{MsgCommand, RRCommandInteraction};
 
 #[tokio::main]
 async fn main() {
@@ -70,11 +16,49 @@ async fn main() {
         env::var("DISCORD_TOKEN").expect("Please set the environment variable DISCORD_TOKEN");
 
     let mut client = Client::builder(token, GatewayIntents::empty())
-        .event_handler(Handler)
+        .event_handler(Handler::new())
         .await
         .expect("Error creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {why:?}");
+    }
+}
+
+struct Handler {
+    command_interactions: Vec<Box<dyn RRCommandInteraction + Sync + Send>>,
+}
+
+impl Handler {
+    fn new() -> Self {
+        Self {
+            command_interactions: vec![Box::new(MsgCommand)],
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for Handler {
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        if let Interaction::Command(command) = interaction {
+            for interaction in &self.command_interactions {
+                if interaction.can_handle(&command) {
+                    if let Err(e) = interaction.handle(&ctx, &command).await {
+                        println!("failed to handle {}: {e}", interaction.name());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn ready(&self, ctx: Context, ready: Ready) {
+        println!("{} is connected!", ready.user.name);
+
+        for interaction in &self.command_interactions {
+            if let Err(e) = interaction.register(&ctx, &ready).await {
+                println!("Failed to register {}: {e}", interaction.name());
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR implements a new slash command `/alturls` exposing existing alt urls functionality.

It also refactors some modules to expose their errors, moving display logic to a new `RRCommandInteraction` abstraction - a generic request-reply command interaction.